### PR TITLE
account, reaction_history 엔티티 unique index 네이밍 변경

### DIFF
--- a/fillin/src/main/java/com/teamfillin/fillin/domain/account/Account.java
+++ b/fillin/src/main/java/com/teamfillin/fillin/domain/account/Account.java
@@ -13,7 +13,7 @@ import javax.persistence.Table;
 @Table(
 	name = "account",
 	indexes = {
-		@Index(name = "idx_unique_01", columnList = "socialType, socialId")
+		@Index(name = "ux_account_social_info", columnList = "socialType, socialId")
 	}
 )
 public class Account {

--- a/fillin/src/main/java/com/teamfillin/fillin/domain/reactionHistory/ReactionHistory.java
+++ b/fillin/src/main/java/com/teamfillin/fillin/domain/reactionHistory/ReactionHistory.java
@@ -14,7 +14,7 @@ import com.teamfillin.fillin.domain.common.BaseTimeEntity;
 @Table(
 	name = "reaction_history",
 	indexes = {
-		@Index(name = "idx_unique_02", columnList = "userNo, targetNo, targetType")
+		@Index(name = "ux_reaction_user_and_target", columnList = "userNo, targetNo, targetType")
 	}
 )
 public class ReactionHistory extends BaseTimeEntity {


### PR DESCRIPTION
### 관련 이슈
- #19 
### Detail
`account`, `reaction_history` 테이블에 unique index 적용 시, 현재 `index_unique_01`, `index_unique_02` 로 네이밍을 했는데,
그래도 좀 더 명확한 이름을 정하는게 좋을 것 같아서 `ux_account_social_info`, `ux_reaction_target` 로 변경하려고 합니다.

말씀 주신대로 index 네이밍에 명확한 규칙은 없는 것 같고, [해당 글](https://purumae.tistory.com/200) 에 따르면 `접두어`-`테이블_이름`-`컬럼_이름` 형식으로 보통 표현하는 것 같습니다. 

다만 jdbc 에서 ddl 생성 시, 인덱스 명에 kebab case 지원를 허용하지 않는 것 같고, 명확한 규칙이 없는 만큼 각 unique index 가 좀 더 의미를 나타낼 수 있도록 각각 `ux_account_social_info`, `ux_reaction_user_and_target` 으로 변경했습니다